### PR TITLE
Fix typo regarding link retrieval

### DIFF
--- a/content/docs/processing-responses.md
+++ b/content/docs/processing-responses.md
@@ -133,7 +133,7 @@ public function parse(Response $response): \Generator
     $links = $response->filter('nav a')->links();
 
     foreach ($links as $link) {
-        yield $this->request('GET', $link->getUrl());
+        yield $this->request('GET', $link->getUri());
     }
 }
 ```


### PR DESCRIPTION
In the iteration of `$links`, a call to a method named `getUrl()` is made. However, this method doesn't actually exist in `Symfony\Component\DomCrawler\Link` -- instead the method I believe we're looking for here is `getUri()` which can be found in `Symfony\Component\DomCrawler\AbstractUriElement`